### PR TITLE
Use mautic instance to track the page visit

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,6 @@
-import React from "react";
-import { Routes, Route, BrowserRouter } from "react-router-dom";
+import React, { useEffect } from "react";
+import { Routes, Route, useLocation } from "react-router-dom";
+import mautic from "./services/mautic_services";
 import Home from "./pages/Home";
 import Layout from "./pages/Layout";
 import About from "./pages/About";
@@ -7,27 +8,48 @@ import Contact from "./pages/Contact";
 import Services from "./pages/Services";
 import ServiceSingle from "./pages/ServiceSingle";
 import ServicePage from "./pages/ServiceSingle";
+// import Blog from "./pages/Blog";
+// import Career from "./pages/Career";
 
 const App = () => {
-  return (
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<Layout />}>
-          <Route>
-            {/* This is where other routes will go to allow Layout to be visible everywhere */}
-            <Route path="/" element={<Home />} />
-            <Route path="/services" element={<Services />} />
-            <Route path="/services/:single" element={<ServiceSingle />} />
-            <Route path="/about" element={<About />} />
-            {/* <Route path="/blog" element={<Blog />} /> */}
-            <Route path="/contact" element={<Contact />} />
-            <Route path="/service-single" element={<ServicePage />} />
-          </Route>
+  const location = useLocation();
 
-          {/* <Route path="*" element={<ErrorPage />} /> */}
+  useEffect(() => {
+    // Update page title dynamically based on the path
+    const pageTitles = {
+      "/": "Homepage",
+      "/services": "Our Services",
+      "/services/:single": "Service Single Page",
+      "/about": "About Us",
+      "/contact": "Contact",
+    };
+    const title = pageTitles[location.pathname] || "Default Title";
+    document.title = title;
+
+    // Track the page view in Mautic
+    mautic.pageView({
+      path: location.pathname,
+      title: document.title,
+    });
+  }, [location]);
+  return (
+    <Routes>
+      <Route path="/" element={<Layout />}>
+        <Route>
+          {/* This is where other routes will go to allow Layout to be visible everywhere */}
+          <Route path="/" element={<Home />} />
+          <Route path="/services" element={<Services />} />
+          <Route path="/services/:single" element={<ServiceSingle />} />
+          <Route path="/about" element={<About />} />
+          {/* <Route path="/blog" element={<Blog />} />
+          <Route path="/career" element={<Career />} /> */}
+          <Route path="/contact" element={<Contact />} />
+          <Route path="/service-single" element={<ServicePage />} />
         </Route>
-      </Routes>
-    </BrowserRouter>
+
+        {/* <Route path="*" element={<ErrorPage />} /> */}
+      </Route>
+    </Routes>
   );
 };
 

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -4,11 +4,14 @@ import App from "./App.jsx";
 import { Provider } from "react-redux";
 import "./Services.css";
 import { store } from "./store/store.js";
+import { BrowserRouter } from "react-router-dom";
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>
     <Provider store={store}>
-      <App />
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
     </Provider>
   </StrictMode>
 );


### PR DESCRIPTION
Related Ticket: TDFP-46

In This PR:
Add mautic tracking in the frontend to get the user's page visit information in the mautic site.

The changes include:
Initialize the mautic page view depending on location  of the user and also the each page visit by the user.

To Test:
Please review the changes and provide feedback.