### PR TITLE
Partners section: setup, render and style

### DIFF
--- a/frontend/src/components/TextImageHome.jsx
+++ b/frontend/src/components/TextImageHome.jsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { URL } from "../services/apiService";
+import { Col, Container, Image, Row } from "react-bootstrap";
+
+const TextImageHome = ({ title, imageUrls }) => {
+  return (
+    <div
+      style={{
+        backgroundColor: "#020204",
+        color: "#FFFFFF",
+        minHeight: "60vh",
+      }}
+    >
+      <Container
+        fluid
+        className="my-5"
+        style={{ paddingLeft: "20px", paddingRight: "20px" }}
+      >
+        <Row className="mb-4">
+          <Col>
+            <h1 style={{ textAlign: "center", marginTop: "30px" }}>{title}</h1>
+          </Col>
+        </Row>
+        <Row>
+          {imageUrls.slice(0, 12).map((imageUrl, index) => (
+            <Col
+              md={3}
+              key={index}
+              className="mb-4"
+              style={{ textAlign: "center" }}
+            >
+              <Image
+                src={`${URL}${imageUrl}`}
+                alt={`image-${index}`}
+                style={{
+                  width: "170px", 
+                  height: "75px", 
+                  display: "block",
+                  margin: "0 auto", // Center the image in the column
+                }}
+              />
+            </Col>
+          ))}
+        </Row>
+      </Container>
+    </div>
+  );
+};
+
+export default TextImageHome;

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -6,6 +6,7 @@ import CardComponent from "../components/CardComponent";
 import { Row, Container, Col } from "react-bootstrap";
 import TextSection from "../components/TextSection";
 import CardImageBg from "../components/CardImageBg";
+import TextImageHome from "../components/TextImageHome";
 
 const Home = () => {
   const dispatch = useDispatch();
@@ -20,25 +21,27 @@ const Home = () => {
           "field_home_content",
           "field_home_content.field_image",
           "field_home_content.field_card_image",
+          "field_home_content.field_text_image",
         ],
       })
     );
   }, [dispatch]);
+  console.log("This is textImageData", homeData.textImageData);
 
   if (loading) return <p>Loading...</p>;
   if (error) return <p>Error: {error}</p>;
 
-  const { heroData, cardData, textData, cardImageData } = homeData;
+  const { heroData, cardData, textData, cardImageData, textImageData } =
+    homeData;
 
   return (
-    <div>
+    <div className="home-page">
       {/* Hero section */}
       {homeData.heroData && (
-        <section>
+        <section className="hero-section">
           <HeroSection {...heroData} />
         </section>
       )}
-
       {/* First Text Section */}
       {homeData.textData && (
         <section className="text-section text-section-1 bg-light py-1">
@@ -51,7 +54,6 @@ const Home = () => {
           </Container>
         </section>
       )}
-
       {/* Cards Section */}
       <section className="card-section my-5">
         <Container fluid>
@@ -65,14 +67,12 @@ const Home = () => {
           </Row>
         </Container>
       </section>
-
       {/* Second Text Section */}
       {homeData.textData && (
         <section className="text-section text-section-2">
           <TextSection {...textData[1]} />
         </section>
       )}
-
       {/* Cards with Images Section */}
       <section className="card-image-section my-5">
         <Container fluid>
@@ -86,8 +86,7 @@ const Home = () => {
           </Row>
         </Container>
       </section>
-
-      {homeData.textData && (
+      {/* {homeData.textData && (
         <section>
           <TextSection
             {...textData[3]}
@@ -95,7 +94,22 @@ const Home = () => {
             textColor="text-white"
           />
         </section>
+      )} */}
+      {/* TextImageLeft Section: Pass only title and all imageUrls */}
+      {homeData.textImageData?.length ? (
+        <section className="partner-section">
+          <TextImageHome
+            title={homeData.textImageData[0]?.title} 
+            imageUrls={homeData.textImageData.map((item) => item.imageUrl)}
+          />
+        </section>
+      ) : (
+        <section className="partner-section">
+          <p>No partner data available</p>
+        </section>
       )}
+      {/* Horizontal Line just to define main content and footer */}
+      <hr style={{ border: "1px solid white", margin: "5px 0" }} />
     </div>
   );
 };


### PR DESCRIPTION
RELATED TICKET: TDFP-68

In this PR:
Create a new component for called TextImageHome for partner section.
Import TextImageHome and render it to the home page.

CHANGES INCLUDE:
New content in the home page.

To Test:
Import drupal database and image folder separately.
Please review the changes and provide feedback.